### PR TITLE
feat: Encrypt and TrustServerCertificate options for servers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ const (
 	DefaultInfluxDBTimeOut   int    = 0
 	DefaultInfluxDBDatabase  string = "SQLSERVER"
 	DefaultInfluxDBPrecision string = "ms"
+
+	DefaultServerEncrypt bool = false
+	DefaultServerTrustServerCertificate bool = false
 )
 
 type TOMLConfig struct {
@@ -65,6 +68,8 @@ type Server struct {
 	Port     int
 	Username string
 	Password string
+	Encrypt  bool
+	TrustServerCertificate bool
 }
 type script struct {
 	Name     string

--- a/influxdb-sqlserver.go
+++ b/influxdb-sqlserver.go
@@ -284,8 +284,8 @@ func init() {
 //
 func connectionString(server cfg.Server) string {
 	return fmt.Sprintf(
-		"Server=%s;Port=%v;User Id=%s;Password=%s;app name=influxdb-sqlserver;log=1",
-		server.IP, server.Port, server.Username, server.Password)
+		"Server=%s;Port=%v;User Id=%s;Password=%s;app name=influxdb-sqlserver;log=1;Encrypt=%t;Trust Server Certificate=%t;",
+		server.IP, server.Port, server.Username, server.Password, server.Encrypt, server.TrustServerCertificate)
 }
 
 //


### PR DESCRIPTION
fixes #18 

This pull request enables you to choose to encrypt the connection to the SQL database, and trust the server certificate, if the provider does not provide a "valid" one.